### PR TITLE
PrestoDB as analog to BigTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ __Please do not list any confidential projects!__
 | Google Internal  | Google Open Source | Open Source    |
 | -------------|------------ |-------------|
 | GFS/Colossus| | HDFS, [Ceph](https://ceph.com), [GlusterFS](https://www.gluster.org) |
-| BigTable     |   | Cassandra, HBase, Accumulo, DynamoDB |
+| BigTable     |   | [PrestoDB](https://prestodb.io/), Cassandra, HBase, Accumulo, DynamoDB |
 | [Spanner](http://research.google.com/archive/spanner.html)   | [cloud spanner](https://cloud.google.com/spanner/) | [CockroachDB](https://github.com/cockroachdb/cockroach) | 
 | columnIO | | Apache Parquet |
 | sstable | levelDB | |


### PR DESCRIPTION
As far as SQL support and in memory MPP PrestoDB might be a better analog than the others listed.