### PR TITLE
add Sourcegraph (for CodeSearch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ __Please do not list any confidential projects!__
 | continuous delivery / releasing | | [lambdaCD](http://www.lambda.cd), screwdriver.cd, [CodeShip](https://codeship.com), [shipit-engine](https://github.com/Shopify/shipit-engine), [GoCD](https://www.gocd.org), [AWS CodeDeploy](https://aws.amazon.com/codedeploy/), [Capistrano](https://www.capistranorb.com), [Fabric](https://www.fabfile.org), [ConcourseCI](https://concourse.ci/)|
 | borg / borgcfg || [AWS Cloudformation](https://aws.amazon.com/cloudformation/), Puppet, Chef, Salt, Ansible, [Terraform](https://www.terraform.io) |
 | logging || logstash, fluentd, papertrail, [cernan](https://github.com/postmates/cernan) |
+| CodeSearch   |             | [Sourcegraph](https://sourcegraph.com) |
 
 ## Operational
 | Google Internal  |   Real World  |


### PR DESCRIPTION
[Sourcegraph](https://sourcegraph.com) serves a similar need to CodeSearch. It provides code search and intelligence for open-source code at Sourcegraph.com and for private code (by running the self-hosted server). Example links:

- Search results: https://sourcegraph.com/search?q=repo:/golang/+file:%5C.go%24+-f:vendor+func+New%5Cw%2B%5C%28.
- Cross-references: https://sourcegraph.com/github.com/golang/go@go1.9/-/blob/src/time/time.go#L620:6$references

Disclaimer: I work at Sourcegraph. I found out about this repository from a [Reddit poster](https://www.reddit.com/r/programming/comments/7z78th/by_exgooglers_for_exgooglers_a_lookup_table_of/dumpyiv/) who seems to agree that Sourcegraph is appropriate to mention here.