### PR TITLE
Update the link to Fabric and Capistrano

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See also: [System Design Primer](https://github.com/donnemartin/system-design-pr
 | Exception/Error Tracking (??) | | Sentry.io, Raygun.io, Rollbar, Honeybadger, Airbrake, OverOps |
 | styleguides | [google styleguides](https://github.com/google/styleguide) | [PEP-8](https://www.python.org/dev/peps/pep-0008/) |
 | blaze test / build / CI | | buildkite, circleCI, travis, jenkins, gitlabCI |
-| continuous delivery / releasing | | [Spinnaker](https://www.spinnaker.io/), [lambdaCD](http://www.lambda.cd), screwdriver.cd, [CodeShip](https://codeship.com), [shipit-engine](https://github.com/Shopify/shipit-engine), [GoCD](https://www.gocd.org), [AWS CodeDeploy](https://aws.amazon.com/codedeploy/), [Capistrano](https://www.capistranorb.com), [Fabric](https://www.fabfile.org), [ConcourseCI](https://concourse.ci/)|
+| continuous delivery / releasing | | [Spinnaker](https://www.spinnaker.io/), [lambdaCD](http://www.lambda.cd), screwdriver.cd, [CodeShip](https://codeship.com), [shipit-engine](https://github.com/Shopify/shipit-engine), [GoCD](https://www.gocd.org), [AWS CodeDeploy](https://aws.amazon.com/codedeploy/), [Capistrano](https://www.capistranorb.com), [Fabric](http://www.fabfile.org), [ConcourseCI](https://concourse.ci/)|
 | borg / borgcfg / gcl || [AWS Cloudformation](https://aws.amazon.com/cloudformation/), Puppet, Chef, Salt, Ansible, [Terraform](https://www.terraform.io), [Jsonnet](http://jsonnet.org/) |
 | logging |[StackDriver](https://cloud.google.com/stackdriver/)| logstash, fluentd, papertrail, [cernan](https://github.com/postmates/cernan) |
 | CodeSearch   | [Zoekt](https://github.com/google/zoekt) | [Sourcegraph](https://sourcegraph.com) |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See also: [System Design Primer](https://github.com/donnemartin/system-design-pr
 | Exception/Error Tracking (??) | | Sentry.io, Raygun.io, Rollbar, Honeybadger, Airbrake, OverOps |
 | styleguides | [google styleguides](https://github.com/google/styleguide) | [PEP-8](https://www.python.org/dev/peps/pep-0008/) |
 | blaze test / build / CI | | buildkite, circleCI, travis, jenkins, gitlabCI |
-| continuous delivery / releasing | | [Spinnaker](https://www.spinnaker.io/), [lambdaCD](http://www.lambda.cd), screwdriver.cd, [CodeShip](https://codeship.com), [shipit-engine](https://github.com/Shopify/shipit-engine), [GoCD](https://www.gocd.org), [AWS CodeDeploy](https://aws.amazon.com/codedeploy/), [Capistrano](https://www.capistranorb.com), [Fabric](http://www.fabfile.org), [ConcourseCI](https://concourse.ci/)|
+| continuous delivery / releasing | | [Spinnaker](https://www.spinnaker.io/), [lambdaCD](http://www.lambda.cd), screwdriver.cd, [CodeShip](https://codeship.com), [shipit-engine](https://github.com/Shopify/shipit-engine), [GoCD](https://www.gocd.org), [AWS CodeDeploy](https://aws.amazon.com/codedeploy/), [Capistrano](http://www.capistranorb.com), [Fabric](http://www.fabfile.org), [ConcourseCI](https://concourse.ci/)|
 | borg / borgcfg / gcl || [AWS Cloudformation](https://aws.amazon.com/cloudformation/), Puppet, Chef, Salt, Ansible, [Terraform](https://www.terraform.io), [Jsonnet](http://jsonnet.org/) |
 | logging |[StackDriver](https://cloud.google.com/stackdriver/)| logstash, fluentd, papertrail, [cernan](https://github.com/postmates/cernan) |
 | CodeSearch   | [Zoekt](https://github.com/google/zoekt) | [Sourcegraph](https://sourcegraph.com) |


### PR DESCRIPTION
The docs of Fabric and Capistrano are hosted in the third party services. 

+ The SSL certificate to <www.fabfile.org> is belong to '*.readthedocs.org'
+ The SSL certificate to <www.capistranorb.com> is belong to '*.github.com'

Even though the 443 ports are open, the certificates are not valid.

If we visit them use `https://`, a `NET::ERR_CERT_COMMON_NAME_INVALID` error will be prompted immediately
