### PR TITLE
Add kubecfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See also: [System Design Primer](https://github.com/donnemartin/system-design-pr
 | styleguides | [google styleguides](https://github.com/google/styleguide) | [PEP-8](https://www.python.org/dev/peps/pep-0008/), [HoundCI auto-style-reviewer](https://houndci.com/) |
 | blaze test / build / CI | | buildkite, [CircleCI](https://circleci.com), travis, jenkins, gitlabCI |
 | continuous delivery / releasing | | [Spinnaker](https://www.spinnaker.io/), [lambdaCD](http://www.lambda.cd), screwdriver.cd, [CodeShip](https://codeship.com), [shipit-engine](https://github.com/Shopify/shipit-engine), [GoCD](https://www.gocd.org), [AWS CodeDeploy](https://aws.amazon.com/codedeploy/), [Capistrano](http://www.capistranorb.com), [Fabric](http://www.fabfile.org), [ConcourseCI](https://concourse.ci/) | [Convox](https://convox.com/) |
-| borg / borgcfg / gcl || [AWS Cloudformation](https://aws.amazon.com/cloudformation/), Puppet, Chef, Salt, Ansible, [Terraform](https://www.terraform.io), [Jsonnet](http://jsonnet.org/) |
+| borg / borgcfg / gcl || [AWS Cloudformation](https://aws.amazon.com/cloudformation/), Puppet, Chef, Salt, Ansible, [Terraform](https://www.terraform.io), [Jsonnet](http://jsonnet.org/), [kubecfg](https://github.com/bitnami/kubecfg) |
 | logging |[StackDriver](https://cloud.google.com/stackdriver/)| logstash, fluentd, papertrail, [cernan](https://github.com/postmates/cernan) |
 | CodeSearch   | [Zoekt](https://github.com/google/zoekt) | [Sourcegraph](https://sourcegraph.com) |
 | Gerrit, Mondrian etc. | | [Reviewable](https://reviewable.io) |


### PR DESCRIPTION
I see that Jsonnet is already mentioned, but the kubecfg projects adds the missing parts, such as the actual update and diff commands and other practical things to talk to the k8s clusters the way you talked to borg.