### PR TITLE
Add pubsub as mapping to kafka and pulsar

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ See also: [System Design Primer](https://github.com/donnemartin/system-design-pr
 | Protocol Buffer   | [Protobuf](https://github.com/google/protobuf)    | [Cap'n Proto](https://capnproto.org/), [Thrift](https://github.com/apache/thrift), [Avro](https://github.com/apache/avro), [Amazon Ion](https://amzn.github.io/ion-docs/)    |
 | Stubby | [gRPC](https://github.com/grpc/grpc) | Bolt, [Thrift](https://github.com/apache/thrift) |
 | Chubby            |      | [Apache Zookeeper](https://github.com/apache/zookeeper), [etcd](https://github.com/coreos/etcd), [HashiCorp Consul](https://github.com/hashicorp/consul)      |
-| ? | | [Apache Kafka](https://github.com/apache/kafka), [Apache Pulsar](https://github.com/apache/incubator-pulsar) |
-
+| pubsub | [pubsub](https://cloud.google.com/pubsub/docs/overview) | [Apache Kafka](https://github.com/apache/kafka), [Apache Pulsar](https://github.com/apache/incubator-pulsar) |
 
 ### Infrastructure
 


### PR DESCRIPTION
Note pubsub is already listed under "Services" and associated with NATS.io, RabbitMQ, PubNub, AWS SQS/SNS, and AWS AppSync.

https://github.com/wadejensen/xg2xg/blob/9be18831b585b6a2dd30dd137b012b74c4bec7c4/README.md#L49

