### PR TITLE
Add ErrorProne

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ See also: [System Design Primer](https://github.com/donnemartin/system-design-pr
 | ToTT                            | [Google Test Blog](https://testing.googleblog.com/) |                                          |
 | Copybara / MOE                  | [Copybara](https://github.com/google/copybara), [MOE](https://github.com/google/MOE)  |                                          |
 | workflow/dependency management | | luigi, airflow, digdag, packyderm, dask |
+| ErrorProne                      | [ErrorProne](https://errorprone.info/)   | [SpotBugs](https://spotbugs.github.io/), [FindBugs](http://findbugs.sourceforge.net/) |
 
 ### Security
 | Google Internal                  | Google External | Open Source                              |


### PR DESCRIPTION
Java static code analyzer to find known bug patterns and bad practices.