### PR TITLE
Add real-world replacements for Colab and PLX

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ See also: [System Design Primer](https://github.com/donnemartin/system-design-pr
 | pubsub                                   | [pubsub](https://cloud.google.com/pubsub/docs/overview) | [NATS.io](https://nats.io), RabbitMQ, [PubNub](https://www.pubnub.com/) | AWS SQS/SNS, [AWS AppSync](https://aws.amazon.com/appsync) |
 | [Flume (Java)](https://ai.google/research/pubs/pub35650) | [Apache Beam](https://beam.apache.org/)  | [Apache Crunch](https://crunch.apache.org/) |                                          |
 | [MillWheel](https://ai.google/research/pubs/pub41378) | [Cloud Dataflow](https://cloud.google.com/dataflow/) | [Apache Flink](https://flink.apache.org/) |                |
+| Colab | [Colaboratory](https://colab.research.google.com/) | [Jupyter](https://jupyter.org) | |
+| PLX | [Google Data Studio](https://datastudio.google.com/) | | [Mode](https://mode.com) |
 
 ### DevOps
 | Google Internal                 | Google External                          | Real-World                               |


### PR DESCRIPTION
This PR lists replacements for PLX (the internal query and dashboard tool) and Colab (the internal notebook).