### PR TITLE
Add Pomerium as Uberproxy alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See also: [System Design Primer](https://github.com/donnemartin/system-design-pr
 | -------------------- | ---------------------------------------- | ---------------------------------------- |
 | Borg                 | [Kubernetes](https://kubernetes.io/)     | [Apache Mesos](https://github.com/apache/mesos), [Apache Aurora](http://aurora.apache.org/), [HashiCorp Nomad](https://github.com/hashicorp/nomad) |
 | GSLB, GFE, Maglev, uberproxy  |                | ELB, [HAProxy](http://www.haproxy.org/), [Istio](https://istio.io/), [F5](https://f5.com/products/big-ip), [envoy](https://github.com/lyft/envoy) |
-| uberproxy (sso proxy) | [buzzfeed-sso](https://github.com/buzzfeed/sso) |
+| uberproxy (sso proxy) | | [buzzfeed-sso](https://github.com/buzzfeed/sso) [Pomerium](https://pomerium.io/) |
 | data center hardware | [open compute](http://www.opencompute.org/) |                                          |
 | Jupiter, Starblaze   |                                          |                                             |
 | B4, Stargate, TE     |                                          |                                             |


### PR DESCRIPTION
Also moved buzzfeed-sso to Open Source column.